### PR TITLE
Issue 9: prevent "Please wait" loader from repeating

### DIFF
--- a/autologout.js
+++ b/autologout.js
@@ -150,6 +150,7 @@
           $.ajax({
             url: Backdrop.settings.basePath + "?q=autologout_ahah_logout",
             type: "POST",
+            progress: {},
             success: function() {
               window.location = localSettings.redirect_url;
             },
@@ -194,6 +195,9 @@
           return ajax.success(response, status);
         };
 
+        // Disable progress element
+        ajax.progress = {};
+
         try {
           ajax.beforeSerialize(ajax.element, ajax.options);
           $.ajax(ajax.options);
@@ -208,7 +212,8 @@
         event: 'autologout.getTimeLeft',
         error: function(XMLHttpRequest, textStatus) {
           // Disable error reporting to the screen.
-        }
+        },
+        progress: {},
       });
 
       /**
@@ -244,6 +249,9 @@
           // Let Backdrop.ajax handle the JSON response.
           return ajax.success(response, status);
         };
+
+        // Disable progress element
+        ajax.progress = {};
 
         try {
           ajax.beforeSerialize(ajax.element, ajax.options);


### PR DESCRIPTION
Addresses #9. This PR rolls in two patches from this [d.o issue](https://www.drupal.org/node/2353251):

* [autologout-2353251-4.patch](https://www.drupal.org/files/issues/autologout-2353251-5.patch)
* [autologout-2353251-5.patch](https://www.drupal.org/files/issues/autologout-2353251-4.patch)

It does seem to prevent the loader from repeating. It doesn't break the tests either, although I'm not sure if the test coverage is complete enough so buyer beware.